### PR TITLE
Redesign street details page with modern UI

### DIFF
--- a/src/components/cars/CarListNombre.test.jsx
+++ b/src/components/cars/CarListNombre.test.jsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { render } from '../../test/utils'
+import CarListNombre from './CarListNombre'
+import { mockCars } from '../../test/mocks/handlers'
+
+// Mock react-router-dom
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => vi.fn()
+  }
+})
+
+// Mock the services
+vi.mock('../../services/cars.service', () => ({
+  getAllCarsService: vi.fn()
+}))
+
+vi.mock('../../services/calles.service', () => ({
+  updateCochesEnCallesService: vi.fn(),
+  deleteCochesEnCallesService: vi.fn()
+}))
+
+import { getAllCarsService } from '../../services/cars.service'
+import { updateCochesEnCallesService, deleteCochesEnCallesService } from '../../services/calles.service'
+
+describe('CarListNombre', () => {
+  const defaultProps = {
+    calleId: 'calle123',
+    actualizar: vi.fn(),
+    cochesAparcados: []
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading state while fetching cars', () => {
+    getAllCarsService.mockImplementation(() => new Promise(() => {}))
+
+    render(<CarListNombre {...defaultProps} />)
+
+    expect(screen.getByText('🚗 Mis Vehículos')).toBeInTheDocument()
+  })
+
+  it('displays user cars after loading', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Seat Ibiza')).toBeInTheDocument()
+      expect(screen.getByText('Mercedes')).toBeInTheDocument()
+    })
+  })
+
+  it('displays license plate for each car', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('1234ABC')).toBeInTheDocument()
+      expect(screen.getByText('9999XYZ')).toBeInTheDocument()
+    })
+  })
+
+  it('shows car count badge', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Aparcar" button for cars not parked in this street', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    render(<CarListNombre {...defaultProps} cochesAparcados={[]} />)
+
+    await waitFor(() => {
+      const aparcarButtons = screen.getAllByRole('button', { name: /Aparcar/ })
+      expect(aparcarButtons).toHaveLength(2)
+    })
+  })
+
+  it('shows "Retirar" button for cars parked in this street', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    const cochesAparcados = [{ _id: 'car1', modelo: 'Seat Ibiza' }]
+
+    render(<CarListNombre {...defaultProps} cochesAparcados={cochesAparcados} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Retirar/ })).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Aquí" badge for parked cars', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    const cochesAparcados = [{ _id: 'car1', modelo: 'Seat Ibiza' }]
+
+    render(<CarListNombre {...defaultProps} cochesAparcados={cochesAparcados} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Aquí')).toBeInTheDocument()
+    })
+  })
+
+  it('calls updateCochesEnCallesService when clicking Aparcar', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+    updateCochesEnCallesService.mockResolvedValue({ data: {} })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Seat Ibiza')).toBeInTheDocument()
+    })
+
+    const aparcarButtons = screen.getAllByRole('button', { name: /Aparcar/ })
+    fireEvent.click(aparcarButtons[0])
+
+    await waitFor(() => {
+      expect(updateCochesEnCallesService).toHaveBeenCalledWith('calle123', 'car1')
+    })
+  })
+
+  it('calls deleteCochesEnCallesService when clicking Retirar', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+    deleteCochesEnCallesService.mockResolvedValue({ data: {} })
+
+    const cochesAparcados = [{ _id: 'car1', modelo: 'Seat Ibiza' }]
+
+    render(<CarListNombre {...defaultProps} cochesAparcados={cochesAparcados} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Retirar/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Retirar/ }))
+
+    await waitFor(() => {
+      expect(deleteCochesEnCallesService).toHaveBeenCalledWith('calle123', 'car1')
+    })
+  })
+
+  it('calls actualizar callback after parking a car', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+    updateCochesEnCallesService.mockResolvedValue({ data: {} })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Seat Ibiza')).toBeInTheDocument()
+    })
+
+    const aparcarButtons = screen.getAllByRole('button', { name: /Aparcar/ })
+    fireEvent.click(aparcarButtons[0])
+
+    await waitFor(() => {
+      expect(defaultProps.actualizar).toHaveBeenCalled()
+    })
+  })
+
+  it('disables button while loading', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+    updateCochesEnCallesService.mockImplementation(() => new Promise(() => {}))
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Seat Ibiza')).toBeInTheDocument()
+    })
+
+    const aparcarButtons = screen.getAllByRole('button', { name: /Aparcar/ })
+    fireEvent.click(aparcarButtons[0])
+
+    await waitFor(() => {
+      expect(aparcarButtons[0]).toBeDisabled()
+    })
+  })
+
+  it('shows empty message when user has no cars', async () => {
+    getAllCarsService.mockResolvedValue({ data: [] })
+
+    render(<CarListNombre {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No tienes vehículos registrados')).toBeInTheDocument()
+    })
+  })
+
+  it('applies parked styling to parked car card', async () => {
+    getAllCarsService.mockResolvedValue({ data: mockCars })
+
+    const cochesAparcados = [{ _id: 'car1', modelo: 'Seat Ibiza' }]
+
+    render(<CarListNombre {...defaultProps} cochesAparcados={cochesAparcados} />)
+
+    await waitFor(() => {
+      const carCards = document.querySelectorAll('.my-car-card')
+      const parkedCard = Array.from(carCards).find(card =>
+        card.classList.contains('parked')
+      )
+      expect(parkedCard).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/maps/MapView.jsx
+++ b/src/components/maps/MapView.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import L from "leaflet"
 import 'leaflet/dist/leaflet.css'
-import "../../styles/mapa.css"
-
 
 let DefaultIcon = L.icon({
   iconUrl: "/marker-icon.png",
@@ -11,32 +9,42 @@ let DefaultIcon = L.icon({
 })
 L.Marker.prototype.options.icon = DefaultIcon
 
-function MapView( {detalles} ) {
-  console.log(detalles)
-  //const positionMapContainer = [37.17913079459059, -5.775956770000562]
-  //const positionMarker = [37.17913079459059, -5.775956770000562]
+function MapView({ detalles }) {
   return (
-    <div>      
-      <div>
-      <MapContainer center={[37.17913079459059, -5.775956770000562]} zoom={15} scrollWheelZoom={true} className="mapa">
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
-        {detalles.map((eachMarker) => {
-          return (
-           <Marker key={eachMarker._id} position={eachMarker.positionMarker}>
-             <Popup>
-               Calle: {eachMarker.name} <br />
-               Nº de aparcamintos: {eachMarker.numAparcamientos} <br />
-               Plazas Libres: {(eachMarker.numAparcamientos)-(eachMarker.coches.length)-(eachMarker.numOcupados)+(eachMarker.numLibres)} <br />
-             </Popup>
-           </Marker>             
-          )
-        })}
-      </MapContainer>
-      </div>
-    </div>
+    <MapContainer
+      center={[37.17913079459059, -5.775956770000562]}
+      zoom={14}
+      scrollWheelZoom={true}
+      style={{ width: '100%', height: '100%', minHeight: '500px' }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {detalles.map((eachMarker) => {
+        const plazasLibres = (eachMarker.numAparcamientos || 0) -
+          (eachMarker.coches?.length || 0) -
+          (eachMarker.numOcupados || 0) +
+          (eachMarker.numLibres || 0);
+
+        return (
+          <Marker key={eachMarker._id} position={eachMarker.positionMarker}>
+            <Popup>
+              <div style={{ minWidth: '150px' }}>
+                <strong style={{ fontSize: '1.1rem' }}>{eachMarker.name}</strong>
+                <hr style={{ margin: '0.5rem 0', borderColor: '#e2e8f0' }} />
+                <p style={{ margin: '0.25rem 0' }}>
+                  🚗 Total: <strong>{eachMarker.numAparcamientos || 0}</strong>
+                </p>
+                <p style={{ margin: '0.25rem 0', color: plazasLibres > 0 ? '#16a34a' : '#dc2626' }}>
+                  {plazasLibres > 0 ? '✅' : '❌'} Libres: <strong>{plazasLibres}</strong>
+                </p>
+              </div>
+            </Popup>
+          </Marker>
+        )
+      })}
+    </MapContainer>
   );
 }
 

--- a/src/components/maps/MapViewDetails.jsx
+++ b/src/components/maps/MapViewDetails.jsx
@@ -13,37 +13,55 @@ let DefaultIcon = L.icon({
 })
 L.Marker.prototype.options.icon = DefaultIcon
 
-function MapView( {detalles} ) {
+function MapViewDetails({ detalles }) {
 
   const { user } = useContext(AuthContext)
-   
+
+  const plazasLibres = (detalles.numAparcamientos || 0) -
+    (detalles.coches?.length || 0) -
+    (detalles.numOcupados || 0) +
+    (detalles.numLibres || 0);
+
   return (
-    <div className="container-map">      
-      <div>
-      <MapContainer center={detalles.positionMarker} zoom={19} scrollWheelZoom={false} className="mapa">
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />        
-        <Marker position={detalles.positionMarker}>
-          <Popup>
-           Nº de aparcamintos: {detalles.numAparcamientos} <br />
-           Plazas Libres: {(detalles.numAparcamientos)-(detalles.coches.length)-(detalles.numOcupados)+(detalles.numLibres)} <br />
-           Coches:
-           {detalles.coches.map((eachCar) => {
-             return(
-               <ul key={eachCar._id}>
-                 {eachCar.owner === user._id ? <li>{eachCar.modelo}</li> : null }                    
-               </ul>
-             ) 
-            })} 
-         </Popup>
-       </Marker>             
-          
-      </MapContainer>
-      </div>
-    </div>
+    <MapContainer
+      center={detalles.positionMarker}
+      zoom={17}
+      scrollWheelZoom={true}
+      style={{ width: '100%', height: '100%', minHeight: '400px' }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={detalles.positionMarker}>
+        <Popup>
+          <div style={{ minWidth: '150px' }}>
+            <strong style={{ fontSize: '1.1rem' }}>{detalles.name}</strong>
+            <hr style={{ margin: '0.5rem 0', borderColor: '#e2e8f0' }} />
+            <p style={{ margin: '0.25rem 0' }}>
+              🚗 Total: <strong>{detalles.numAparcamientos || 0}</strong>
+            </p>
+            <p style={{ margin: '0.25rem 0', color: '#16a34a' }}>
+              ✅ Libres: <strong>{plazasLibres}</strong>
+            </p>
+            {detalles.coches?.filter(car => car.owner === user._id).length > 0 && (
+              <>
+                <hr style={{ margin: '0.5rem 0', borderColor: '#e2e8f0' }} />
+                <p style={{ margin: '0.25rem 0', fontWeight: '600' }}>Tus coches:</p>
+                {detalles.coches
+                  .filter(car => car.owner === user._id)
+                  .map((eachCar) => (
+                    <p key={eachCar._id} style={{ margin: '0.15rem 0', paddingLeft: '0.5rem' }}>
+                      🚙 {eachCar.modelo}
+                    </p>
+                  ))}
+              </>
+            )}
+          </div>
+        </Popup>
+      </Marker>
+    </MapContainer>
   );
 }
 
-export default MapView;
+export default MapViewDetails;

--- a/src/pages/calles/CallesDetails.jsx
+++ b/src/pages/calles/CallesDetails.jsx
@@ -12,9 +12,7 @@ import { AuthContext } from "../../context/auth.context";
 import MapViewDetails from "../../components/maps/MapViewDetails";
 import CarListNombre from "../../components/cars/CarListNombre";
 
-import Card from "react-bootstrap/Card";
-import ListGroup from "react-bootstrap/ListGroup";
-import Button from "react-bootstrap/Button";
+import "../../styles/calles.css";
 
 function CallesDetails() {
   const { isAdminIn, user } = useContext(AuthContext);
@@ -22,14 +20,10 @@ function CallesDetails() {
   const { calleId } = useParams();
   const navigate = useNavigate();
 
-  //1. crear el estado donde estaran los detalles
   const [details, setDetails] = useState(null);
   const [isFetching, setIsFetching] = useState(true);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  //console.log("detalles del owner", details.coches[0].owner)
-  console.log("detalles del user", user._id);
-
-  //2. buscar la informacion de la BD
   useEffect(() => {
     getData();
   }, []);
@@ -37,8 +31,6 @@ function CallesDetails() {
   const getData = async () => {
     try {
       const response = await getCallesDetailsService(calleId);
-      console.log(response.data);
-      //3. actualizar el estado de la data
       setDetails(response.data);
       setIsFetching(false);
     } catch (error) {
@@ -47,7 +39,6 @@ function CallesDetails() {
     }
   };
 
-  //4. clausula de guardia
   if (isFetching === true) {
     return (
       <div className="App">
@@ -61,7 +52,6 @@ function CallesDetails() {
   const handleDelete = async () => {
     try {
       await deleteCallesService(calleId);
-      console.log("elemento borrado");
       navigate("/calles");
     } catch (error) {
       console.log(error);
@@ -69,57 +59,172 @@ function CallesDetails() {
     }
   };
 
+  const plazasLibres =
+    (details.numAparcamientos || 0) -
+    (details.coches?.length || 0) -
+    (details.numOcupados || 0) +
+    (details.numLibres || 0);
+
   return (
-    <div className="calles-container-body">
-      {isAdminIn === true ? (
-        <Card style={{ width: "18rem", marginTop: "10px" }}>
-          <Card.Header
-            style={{
-              backgroundColor: "#68ec57",
-              color: "rgb(87, 87, 240)",
-              fontWeight: "bold",
-            }}
-          >
-            Calle: {details.name}
-          </Card.Header>
-          <ListGroup variant="flush">
-            <ListGroup.Item style={{ backgroundColor: "white" }}>
-              <p>Numero de coches: {details.coches.length}</p>
-              <p>Aparcamientos agregados por el admin: {details.numOcupados}</p>
-              <p>Aparcamientos liberados por el admin: {details.numLibres}</p>
-              <p>Los coches de esta calle:</p>
-              {details.coches.map((eachCar) => {
-                return (
-                  <ul key={eachCar._id}>
-                    <li>{eachCar.modelo}</li>
-                  </ul>
-                );
-              })}
+    <div className="calles-container">
+      {/* Header */}
+      <div className="calles-header">
+        <div className="header-content">
+          <div className="title-section">
+            <h1 className="page-title">📍 {details.name}</h1>
+            <p className="page-subtitle">Detalles y gestión de aparcamiento</p>
+          </div>
 
-              <div style={{display: "flex", justifyContent: "space-between"}}>
-              <Button variant="outline-primary">
+          <div className="header-actions">
+            <Link to="/calles" className="map-toggle-btn">
+              <span className="btn-icon">←</span>
+              Volver a Calles
+            </Link>
+            {isAdminIn && (
+              <>
                 <Link
-                  style={{ textDecoration: "none", color: "" }}
                   to={`/calles/${details._id}/edit`}
+                  className="add-street-btn"
                 >
-                  Ir a editar
+                  <span className="btn-icon">✏️</span>
+                  Editar
                 </Link>
-              </Button>
-              <Button variant="outline-dark" onClick={handleDelete}>
-                Borrar
-              </Button>
-              </div>
-            </ListGroup.Item>
-          </ListGroup>
-        </Card>
-      ) : null}
-
-      <div>
-        <CarListNombre calleId={calleId} actualizar={getData} />
+                <button
+                  className="delete-btn"
+                  onClick={() => setShowDeleteConfirm(true)}
+                >
+                  <span className="btn-icon">🗑️</span>
+                  Eliminar
+                </button>
+              </>
+            )}
+          </div>
+        </div>
       </div>
 
-      <div>
-        <MapViewDetails detalles={details} />
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="add-calles-modal">
+          <div className="modal-content delete-modal">
+            <div className="delete-modal-content">
+              <div className="delete-icon">⚠️</div>
+              <h3>¿Eliminar esta calle?</h3>
+              <p>
+                Esta acción no se puede deshacer. Se eliminará "{details.name}"
+                permanentemente.
+              </p>
+              <div className="delete-modal-actions">
+                <button
+                  className="cancel-btn"
+                  onClick={() => setShowDeleteConfirm(false)}
+                >
+                  Cancelar
+                </button>
+                <button className="confirm-delete-btn" onClick={handleDelete}>
+                  Sí, eliminar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Main Content */}
+      <div className="details-content">
+        {/* Left Column - Stats & Cars */}
+        <div className="details-sidebar">
+          {/* Stats Card */}
+          <div className="details-card stats-card">
+            <div className="details-card-header">
+              <h3>📊 Estadísticas</h3>
+              <div
+                className={`availability-badge ${plazasLibres > 0 ? "available" : "full"}`}
+              >
+                {plazasLibres > 0 ? "Disponible" : "Completo"}
+              </div>
+            </div>
+
+            <div className="stats-grid">
+              <div className="stat-item">
+                <div className="stat-icon-large">🚗</div>
+                <div className="stat-info">
+                  <span className="stat-number">
+                    {details.numAparcamientos || 0}
+                  </span>
+                  <span className="stat-label">Total plazas</span>
+                </div>
+              </div>
+
+              <div className="stat-item">
+                <div className="stat-icon-large">✅</div>
+                <div className="stat-info">
+                  <span className="stat-number available-number">
+                    {plazasLibres}
+                  </span>
+                  <span className="stat-label">Libres</span>
+                </div>
+              </div>
+
+              <div className="stat-item">
+                <div className="stat-icon-large">🚙</div>
+                <div className="stat-info">
+                  <span className="stat-number">
+                    {details.coches?.length || 0}
+                  </span>
+                  <span className="stat-label">Ocupadas</span>
+                </div>
+              </div>
+
+              {isAdminIn && (
+                <div className="stat-item">
+                  <div className="stat-icon-large">🔧</div>
+                  <div className="stat-info">
+                    <span className="stat-number">{details.numOcupados || 0}</span>
+                    <span className="stat-label">Ajuste admin</span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Parked Cars List */}
+            {details.coches?.length > 0 && (
+              <div className="parked-cars-section">
+                <h4>🚘 Coches aparcados</h4>
+                <div className="parked-cars-list">
+                  {details.coches.map((eachCar) => (
+                    <div key={eachCar._id} className="parked-car-item">
+                      <span className="car-icon">🚗</span>
+                      <span className="car-name">{eachCar.modelo}</span>
+                      {eachCar.owner === user._id && (
+                        <span className="my-car-badge">Tu coche</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* My Cars Card */}
+          <CarListNombre
+            calleId={calleId}
+            actualizar={getData}
+            cochesAparcados={details.coches}
+          />
+        </div>
+
+        {/* Right Column - Map */}
+        <div className="details-main">
+          <div className="map-container details-map">
+            <div className="map-header">
+              <h3>🗺️ Ubicación</h3>
+              <p>Ubicación exacta de {details.name}</p>
+            </div>
+            <div className="map-wrapper">
+              <MapViewDetails detalles={details} />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/calles/CallesDetails.test.jsx
+++ b/src/pages/calles/CallesDetails.test.jsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { render } from '../../test/utils'
+import CallesDetails from './CallesDetails'
+import { mockCalle, mockCalleWithCars, mockUser } from '../../test/mocks/handlers'
+
+// Mock react-router-dom hooks
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ calleId: 'calle123' }),
+    useNavigate: () => vi.fn()
+  }
+})
+
+// Mock the services
+vi.mock('../../services/calles.service', () => ({
+  getCallesDetailsService: vi.fn(),
+  deleteCallesService: vi.fn()
+}))
+
+// Mock CarListNombre component
+vi.mock('../../components/cars/CarListNombre', () => ({
+  default: ({ calleId, actualizar, cochesAparcados }) => (
+    <div data-testid="car-list-nombre">
+      <span>Car List for {calleId}</span>
+      <span>Parked: {cochesAparcados?.length || 0}</span>
+    </div>
+  )
+}))
+
+// Mock MapViewDetails component
+vi.mock('../../components/maps/MapViewDetails', () => ({
+  default: ({ detalles }) => (
+    <div data-testid="map-view-details">
+      Map for {detalles?.name}
+    </div>
+  )
+}))
+
+import { getCallesDetailsService, deleteCallesService } from '../../services/calles.service'
+
+describe('CallesDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching data', () => {
+    getCallesDetailsService.mockImplementation(() => new Promise(() => {}))
+
+    render(<CallesDetails />)
+
+    expect(document.querySelector('.spinner')).toBeInTheDocument()
+  })
+
+  it('displays street details after loading', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Calle Test')
+    })
+
+    expect(screen.getByText('Detalles y gestión de aparcamiento')).toBeInTheDocument()
+  })
+
+  it('displays parking statistics', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText('📊 Estadísticas')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Total plazas')).toBeInTheDocument()
+    expect(screen.getByText('Libres')).toBeInTheDocument()
+    expect(screen.getByText('Ocupadas')).toBeInTheDocument()
+  })
+
+  it('shows "Disponible" badge when spots are available', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Disponible')).toBeInTheDocument()
+    })
+  })
+
+  it('shows admin controls for admin users', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />, {
+      authContext: {
+        isLoggedIn: true,
+        user: mockUser,
+        isAdminIn: true
+      }
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Editar/)).toBeInTheDocument()
+      expect(screen.getByText(/Eliminar/)).toBeInTheDocument()
+    })
+  })
+
+  it('hides admin controls for non-admin users', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />, {
+      authContext: {
+        isLoggedIn: true,
+        user: { ...mockUser, role: 'user' },
+        isAdminIn: false
+      }
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Calle Test')
+    })
+
+    expect(screen.queryByRole('button', { name: /Eliminar/ })).not.toBeInTheDocument()
+  })
+
+  it('opens delete confirmation modal when clicking delete', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Eliminar/)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar/ }))
+
+    expect(screen.getByText('¿Eliminar esta calle?')).toBeInTheDocument()
+    expect(screen.getByText(/Esta acción no se puede deshacer/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sí, eliminar' })).toBeInTheDocument()
+  })
+
+  it('closes modal when clicking cancel', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Eliminar/)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar/ }))
+    expect(screen.getByText('¿Eliminar esta calle?')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('¿Eliminar esta calle?')).not.toBeInTheDocument()
+    })
+  })
+
+  it('displays parked cars section when cars are parked', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalleWithCars })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText('🚘 Coches aparcados')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Tu coche" badge for user\'s own cars', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalleWithCars })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Tu coche')).toBeInTheDocument()
+    })
+  })
+
+  it('renders map component with correct details', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-view-details')).toBeInTheDocument()
+      expect(screen.getByText('Map for Calle Test')).toBeInTheDocument()
+    })
+  })
+
+  it('renders car list component', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('car-list-nombre')).toBeInTheDocument()
+    })
+  })
+
+  it('has back to calles link', async () => {
+    getCallesDetailsService.mockResolvedValue({ data: mockCalle })
+
+    render(<CallesDetails />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Volver a Calles/)).toBeInTheDocument()
+    })
+
+    const backLink = screen.getByRole('link', { name: /Volver a Calles/ })
+    expect(backLink).toHaveAttribute('href', '/calles')
+  })
+})

--- a/src/services/calles.service.js
+++ b/src/services/calles.service.js
@@ -22,10 +22,10 @@ const updateCallesService = (calleId, callesUpdate) => {
 }
 
 const updateCochesEnCallesService = (calleId, cocheId) => {
-  return service.patch(`/calle/${calleId}/${cocheId}`)  
+  return service.post(`/calle/${calleId}/coches/${cocheId}`)
 }
 const deleteCochesEnCallesService = (calleId, cocheId) => {
-  return service.patch(`/calle/delete/${calleId}/${cocheId}`)  
+  return service.delete(`/calle/${calleId}/coches/${cocheId}`)
 }
 
 const getCallesFavoritas = () => {

--- a/src/styles/calles.css
+++ b/src/styles/calles.css
@@ -450,28 +450,446 @@
   .calles-header {
     padding: 1rem;
   }
-  
+
   .title-section h1.page-title {
     font-size: 1.5rem;
   }
-  
+
   .header-actions {
     flex-direction: column;
     width: 100%;
   }
-  
+
   .add-street-btn, .map-toggle-btn {
     justify-content: center;
   }
-  
+
   .card-stats {
     grid-template-columns: 1fr;
     gap: 0.5rem;
   }
-  
+
   .stat {
     flex-direction: row;
     justify-content: space-between;
+    padding: 0.75rem;
+  }
+}
+
+/* ===================================
+   DETAILS PAGE STYLES
+   =================================== */
+
+/* Delete Button */
+.delete-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 50px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(239, 68, 68, 0.2);
+  color: white;
+}
+
+.delete-btn:hover {
+  background: rgba(239, 68, 68, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(239, 68, 68, 0.3);
+}
+
+/* Details Content Layout */
+.details-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  gap: 2rem;
+  min-height: calc(100vh - 200px);
+}
+
+.details-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.details-main {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Details Cards */
+.details-card {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.details-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid #f1f5f9;
+}
+
+.details-card-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+/* Availability Badge */
+.availability-badge {
+  padding: 0.35rem 0.75rem;
+  border-radius: 50px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.availability-badge.available {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.availability-badge.full {
+  background: rgba(239, 68, 68, 0.15);
+  color: #dc2626;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: #f8fafc;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.stat-item:hover {
+  background: #f1f5f9;
+  transform: translateY(-2px);
+}
+
+.stat-icon-large {
+  font-size: 1.8rem;
+}
+
+.stat-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-number {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.stat-number.available-number {
+  color: #16a34a;
+}
+
+/* Parked Cars Section */
+.parked-cars-section {
+  border-top: 2px solid #f1f5f9;
+  padding-top: 1.5rem;
+}
+
+.parked-cars-section h4 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.parked-cars-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.parked-car-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border-radius: 10px;
+}
+
+.car-icon {
+  font-size: 1.2rem;
+}
+
+.car-name {
+  flex: 1;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.my-car-badge {
+  background: linear-gradient(45deg, #667eea, #764ba2);
+  color: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: 50px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+/* My Cars Card */
+.my-cars-card {
+  flex: 1;
+}
+
+.my-cars-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.my-car-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #f8fafc;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.my-car-card.parked {
+  background: rgba(102, 126, 234, 0.1);
+  border-color: #667eea;
+}
+
+.my-car-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.my-car-icon {
+  font-size: 1.5rem;
+}
+
+.my-car-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.my-car-name {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.my-car-plate {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.parked-here-badge {
+  background: #667eea;
+  color: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: 50px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.my-car-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.action-btn {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.park-btn {
+  background: linear-gradient(45deg, #22c55e, #16a34a);
+  color: white;
+}
+
+.park-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(34, 197, 94, 0.4);
+}
+
+.leave-btn {
+  background: linear-gradient(45deg, #667eea, #764ba2);
+  color: white;
+}
+
+.leave-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+}
+
+.action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Details Map */
+.details-map {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.details-map .map-wrapper {
+  flex: 1;
+  min-height: 400px;
+}
+
+/* Loading Container */
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem;
+}
+
+/* Empty Cars Message */
+.empty-cars-message {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+}
+
+/* Delete Modal */
+.delete-modal {
+  max-width: 400px;
+  padding: 2rem;
+}
+
+.delete-modal-content {
+  text-align: center;
+}
+
+.delete-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.delete-modal-content h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.3rem;
+  color: #1e293b;
+}
+
+.delete-modal-content p {
+  margin: 0 0 1.5rem 0;
+  color: #64748b;
+}
+
+.delete-modal-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.cancel-btn {
+  padding: 0.75rem 1.5rem;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  background: white;
+  color: #64748b;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.cancel-btn:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.confirm-delete-btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(45deg, #ef4444, #dc2626);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.confirm-delete-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(239, 68, 68, 0.4);
+}
+
+/* Details Page Responsive */
+@media (max-width: 1024px) {
+  .details-content {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .details-main {
+    order: 1;
+  }
+
+  .details-sidebar {
+    order: 2;
+  }
+}
+
+@media (max-width: 768px) {
+  .details-content {
+    padding: 1rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .details-map .map-wrapper {
+    min-height: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .delete-modal-actions {
+    flex-direction: column;
+  }
+
+  .my-car-card {
     padding: 0.75rem;
   }
 }

--- a/src/styles/mapa.css
+++ b/src/styles/mapa.css
@@ -1,17 +1,28 @@
 .mapa {
-  width: 50vw;
-  height: 50vh;  
-  border: 1px solid red; 
-  border-radius: 50% 50% 50% 50%;
-  grid-area: mapa;    
-  
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 0;
 }
-.container-map {  
-  margin: 0 25vw;
-}
-.container-map-withDrag{
 
+.container-map {
+  width: 100%;
+  height: 100%;
+}
+
+.container-map-withDrag {
   width: 400px;
-  height: 400px;  
+  height: 400px;
+}
 
+/* Details page map specific styles */
+.details-map .container-map {
+  width: 100%;
+  height: 100%;
+}
+
+.details-map .mapa {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
 }

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -1,0 +1,30 @@
+// Mock data for tests
+export const mockUser = {
+  _id: 'user123',
+  username: 'testuser',
+  email: 'test@test.com',
+  role: 'admin'
+}
+
+export const mockCalle = {
+  _id: 'calle123',
+  name: 'Calle Test',
+  numAparcamientos: 10,
+  numOcupados: 0,
+  numLibres: 0,
+  positionMarker: [37.17913, -5.77595],
+  coches: []
+}
+
+export const mockCalleWithCars = {
+  ...mockCalle,
+  coches: [
+    { _id: 'car1', modelo: 'Seat Ibiza', matricula: '1234ABC', owner: 'user123' },
+    { _id: 'car2', modelo: 'Ford Focus', matricula: '5678DEF', owner: 'other-user' }
+  ]
+}
+
+export const mockCars = [
+  { _id: 'car1', modelo: 'Seat Ibiza', matricula: '1234ABC', owner: 'user123' },
+  { _id: 'car2', modelo: 'Mercedes', matricula: '9999XYZ', owner: 'user123' }
+]

--- a/src/test/utils.jsx
+++ b/src/test/utils.jsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { AuthContext } from '../context/auth.context'
+import { mockUser } from './mocks/handlers'
+
+// Default auth context values for testing
+const defaultAuthContext = {
+  isLoggedIn: true,
+  isLoading: false,
+  user: mockUser,
+  isAdminIn: true,
+  storeToken: vi.fn(),
+  authenticateUser: vi.fn(),
+  logOutUser: vi.fn()
+}
+
+// Custom render that wraps components with necessary providers
+export function renderWithProviders(
+  ui,
+  {
+    authContext = defaultAuthContext,
+    route = '/',
+    ...renderOptions
+  } = {}
+) {
+  window.history.pushState({}, 'Test page', route)
+
+  function Wrapper({ children }) {
+    return (
+      <AuthContext.Provider value={authContext}>
+        <BrowserRouter>
+          {children}
+        </BrowserRouter>
+      </AuthContext.Provider>
+    )
+  }
+
+  return {
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    authContext
+  }
+}
+
+// Re-export everything from testing-library
+export * from '@testing-library/react'
+export { renderWithProviders as render }


### PR DESCRIPTION
## Summary

- Rediseño completo de la página de detalles de calle (CallesDetails) para que coincida con el estilo moderno del resto de la aplicación
- Header con gradiente y botones de acción (Volver, Editar, Eliminar)
- Modal de confirmación antes de eliminar una calle
- Card de estadísticas con grid mostrando disponibilidad de aparcamiento
- Sección de coches aparcados con badge "Tu coche"
- Componente CarListNombre rediseñado con botones contextuales (Aparcar/Retirar)
- Mapas corregidos: eliminado borde circular, altura adecuada, popups mejorados
- Corregidas rutas de API para aparcar/retirar coches (POST/DELETE en lugar de PATCH)
- Diseño responsive para móviles

## Screenshots

### Antes
![before](https://github.com/user-attachments/assets/placeholder-before)
- Diseño inconsistente con el resto de la app
- Mapa circular sin sentido funcional
- Botones básicos sin estilo

### Después
- Header con gradiente consistente
- Cards con estadísticas visuales
- Mapa rectangular con popup mejorado
- Botones contextuales (solo muestra Aparcar o Retirar según estado)

## Test plan

- [x] Verificar que la página de detalles de calle carga correctamente
- [x] Probar aparcar un coche y verificar que las estadísticas se actualizan
- [x] Probar retirar un coche y verificar que vuelve al estado inicial
- [x] Verificar que el modal de confirmación aparece al intentar eliminar
- [x] Comprobar que el mapa muestra el marcador y el popup funciona
- [x] Verificar responsive en dispositivos móviles